### PR TITLE
Adding stringtype support in postgres jdbcurl 

### DIFF
--- a/openidm-zip/src/main/resources/db/postgresql/conf/repo.jdbc.json
+++ b/openidm-zip/src/main/resources/db/postgresql/conf/repo.jdbc.json
@@ -3,7 +3,7 @@
         "dbType" : "POSTGRESQL",
         "jndiName" : "",
         "driverClass" : "org.postgresql.Driver",
-        "jdbcUrl" : "jdbc:postgresql://localhost:5432/openidm",
+        "jdbcUrl" : "jdbc:postgresql://localhost:5432/openidm?stringtype=unspecified",
         "username" : "openidm",
         "password" : "openidm",
         "defaultCatalog" : "openidm",


### PR DESCRIPTION
From the documentation [1] I read that postgres supports an option, called stringtype. This option "Specify the type to use when binding PreparedStatement parameters set via setString()". I tried to inspect OpenIDM code, and I noticed it is using this kind of binding. Again from doc "If stringtype is set to VARCHAR (the default), such parameters will be sent to the server as varchar parameters. If stringtype is set to unspecified, parameters will be sent to the server as untyped values, and the server will attempt to infer an appropriate type". I think that the jdbc connector, without specifing the stringtype parameter, will cast any received string as a varchar, during the setString call. Postgres, when it will receive that value, it will pick up the less powerful type and will continue with a restricted type.

This parameter could be useful when we want to perform a case insensitive search. If we are not specifying the stringtype parameter, we will receive every time a varchar. Suppose that we want to perform a search against a column with a citext type. Postgress first will pick up the less powerful type, in this case varchar, and then it will perform the comparison: however it will be performed between two varchar, and it will not be case insensitive.

Forcing the stringtype to be unspecified will trigger postgres to infer the type of that value received, and it seems that is considering the received field as citext.

[1] https://jdbc.postgresql.org/documentation/94/connect.html
